### PR TITLE
Add Rails::VERSION module to test monkey-patches

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -19,8 +19,17 @@ end
 # can, and capybara/rails assumes there is a full rails env present. So this is a
 # hack to make it not fail.
 module Rails
+  module VERSION
+    MAJOR = 3
+    MINOR = 0
+    TINY  = 0
+    PRE   = ""
+
+    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+  end
+
   def self.version
-    '3.0'
+    VERSION::STRING
   end
 
   def self.root


### PR DESCRIPTION
rspec-rails (or more specifically RailsExampleGroup) expects the
new Rails::VERSION module to exist. We could restrict the rspec-rails
version but that's probably asking for more problems in the long
run.

Before this commit, tests using rspec-rails 2.13.x failed with:

/gems/rspec-rails-2.13.2/lib/rspec/rails/example/rails_example_group.rb:10:in
`module:RailsExampleGroup': uninitialized constant Rails::VERSION (NameError)
