### PR TITLE
Allow default rails interface in functional tests of controllers

### DIFF
--- a/lib/focused_controller/functional_test_helper.rb
+++ b/lib/focused_controller/functional_test_helper.rb
@@ -3,23 +3,34 @@ require 'active_support/concern'
 module FocusedController
   module FunctionalTestHelper
     def get(*args)
-      super(FocusedController.action_name, *args)
+      new_args = args_with_action_name(*args)
+      super(*new_args)
     end
 
     def post(*args)
-      super(FocusedController.action_name, *args)
+      super(*args_with_action_name(*args))
     end
 
     def put(*args)
-      super(FocusedController.action_name, *args)
+      super(*args_with_action_name(*args))
     end
 
     def delete(*args)
-      super(FocusedController.action_name, *args)
+      super(*args_with_action_name(*args))
     end
 
     def head(*args)
-      super(FocusedController.action_name, *args)
+      super(*args_with_action_name(*args))
+    end
+
+    private
+
+    def args_with_action_name(*args)
+      if args.first.is_a?(Symbol)
+        args
+      else
+        [FocusedController.action_name] + args
+      end
     end
   end
 end

--- a/test/unit/functional_test_helper_test.rb
+++ b/test/unit/functional_test_helper_test.rb
@@ -45,20 +45,57 @@ module FocusedController
           end
         end
 
-        subject.get :foo, :bar, :baz
-        subject.last_process.must_equal ['call', :foo, :bar, :baz, 'GET']
+        parameters = {:foo => "bar"}
+        session = {:baz => "bat"}
+        flash = {:quux => "wibble"}
 
-        subject.post :foo, :bar, :baz
-        subject.last_process.must_equal ['call', :foo, :bar, :baz, 'POST']
 
-        subject.put :foo, :bar, :baz
-        subject.last_process.must_equal ['call', :foo, :bar, :baz, 'PUT']
+        subject.get parameters, session, flash
+        subject.last_process.must_equal ['call', parameters, session, flash, 'GET']
 
-        subject.delete :foo, :bar, :baz
-        subject.last_process.must_equal ['call', :foo, :bar, :baz, 'DELETE']
+        subject.post parameters, session, flash
+        subject.last_process.must_equal ['call', parameters, session, flash, 'POST']
 
-        subject.head :foo, :bar, :baz
-        subject.last_process.must_equal ['call', :foo, :bar, :baz, 'HEAD']
+        subject.put parameters, session, flash
+        subject.last_process.must_equal ['call', parameters, session, flash, 'PUT']
+
+        subject.delete parameters, session, flash
+        subject.last_process.must_equal ['call', parameters, session, flash, 'DELETE']
+
+        subject.head parameters, session, flash
+        subject.last_process.must_equal ['call', parameters, session, flash, 'HEAD']
+      end
+
+
+      describe "testing a non-focused controller" do
+        it "allows using the action name to dispatch the action" do
+          subject.singleton_class.class_eval do
+            attr_reader :last_process
+
+            def process(*args)
+              @last_process = args
+            end
+          end
+
+          parameters = {:foo => "bar"}
+          session = {:baz => "bat"}
+          flash = {:quux => "wibble"}
+
+          subject.get :show, parameters, session, flash
+          subject.last_process.must_equal [:show, parameters, session, flash, 'GET']
+
+          subject.post :create, parameters, session, flash
+          subject.last_process.must_equal [:create, parameters, session, flash, 'POST']
+
+          subject.put :update, parameters, session, flash
+          subject.last_process.must_equal [:update, parameters, session, flash, 'PUT']
+
+          subject.delete :destroy, parameters, session, flash
+          subject.last_process.must_equal [:destroy, parameters, session, flash, 'DELETE']
+
+          subject.head :show, parameters, session, flash
+          subject.last_process.must_equal [:show, parameters, session, flash, 'HEAD']
+        end
       end
     end
   end


### PR DESCRIPTION
Hi Jon!

Thanks a lot for focused_controller - it's tidied up the controller layer of the app I'm working on at the moment no end!

This patch is a very small proposal regarding the functional testing helpers. In my app, all but one of my controllers use focused controller, so therefore I thought I'd include the helpers in all my controller specs using the rspec config:

```
config.include FocusedController::RSpecFunctionalHelpers, :type => :controller 
```

However, I have one controller that's un-focused (as it needs to override some behaviour in Devise), and sadly this breaks my vanilla rails controller specs for that.

This patch adapts the functional test helpers to allow them to be called with an action name optionally, (as in the default rails implementation), defaulting to the FocusedController action name if none is supplied, therefore ensuring that including the functional helpers doesn't break existing rails controller specs.

Thanks!

Tim
