### PR TITLE
Release ActionPack dependency to < 4.2

### DIFF
--- a/focused_controller.gemspec
+++ b/focused_controller.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'actionpack', '>= 3.0', '<= 4.1'
+  s.add_dependency 'actionpack', '>= 3.0', '< 4.2'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'capybara',               '~> 2.1'


### PR DESCRIPTION
Without this change bundler reports following with Rails 4.1.1:

```
Bundler could not find compatible versions for gem "actionpack":
  In Gemfile:
    focused_controller (~> 1.2.0) ruby depends on
      actionpack (<= 4.1, >= 3.0) ruby
```
