### PR TITLE
Bugfix for rails-4.2.5.1

### DIFF
--- a/lib/focused_controller/route_mapper.rb
+++ b/lib/focused_controller/route_mapper.rb
@@ -77,7 +77,7 @@ module FocusedController
 
     def controller_reference(controller_param)
       if controller_param.include?(FOCUSED_CONTROLLER)
-        const_name = @controller_class_names[controller_param] ||= controller_param.camelize
+        const_name = controller_param.camelize
         ActiveSupport::Dependencies.constantize(const_name)
       else
         super


### PR DESCRIPTION
A recent commit to actionpack broke RouteDispatcherExtensions#controller_reference:
https://github.com/rails/rails/commit/710c5ce91acd8b4277dc105e60bc5bda90ccbd8a
This change makes it compatible both with the latest, and previous versions of rails.
